### PR TITLE
Control.Arrow.Free: Add compatibility with profunctor

### DIFF
--- a/free-category.cabal
+++ b/free-category.cabal
@@ -44,6 +44,7 @@ library
   build-depends:
       base           >= 4.9 && < 5.0
     , free-algebras ^>= 0.1.1.0 || ^>= 0.1.2
+    , profunctors   ^>= 5.6
   ghc-options:
     -Wall
     -fwarn-incomplete-record-updates

--- a/src/Control/Arrow/Free.hs
+++ b/src/Control/Arrow/Free.hs
@@ -37,6 +37,7 @@ module Control.Arrow.Free
 import           Prelude hiding (id, (.))
 import           Control.Arrow (Arrow (..), ArrowChoice (..), (>>>))
 import           Control.Category (Category (..))
+import           Data.Profunctor
 
 import           Control.Algebra.Free2
   ( AlgebraType0
@@ -101,6 +102,10 @@ instance Arrow (Arr f) where
   ab *** xy = Prod (ab . arr fst) (xy . arr snd)
   (&&&)     = Prod
 
+instance Profunctor (Arr f) where
+  lmap f a = arr f >>> a
+  rmap = Arr
+
 type instance AlgebraType0 Arr f = ()
 type instance AlgebraType  Arr c = Arrow c
 
@@ -154,6 +159,10 @@ instance Arrow (A f) where
   A f *** A g  = A $ \k -> f k *** g k
   first  (A f) = A $ \k -> first (f k)
   second (A f) = A $ \k -> second (f k)
+
+instance Profunctor (A f) where
+  lmap f a = arr f >>> a
+  rmap f a = a >>> arr f
 
 type instance AlgebraType0 A f = ()
 type instance AlgebraType  A c = Arrow c

--- a/src/Control/Arrow/Free.hs
+++ b/src/Control/Arrow/Free.hs
@@ -37,7 +37,7 @@ module Control.Arrow.Free
 import           Prelude hiding (id, (.))
 import           Control.Arrow (Arrow (..), ArrowChoice (..), (>>>))
 import           Control.Category (Category (..))
-import           Data.Profunctor
+import           Data.Profunctor (Profunctor (..))
 
 import           Control.Algebra.Free2
   ( AlgebraType0

--- a/src/Control/Arrow/Free.hs
+++ b/src/Control/Arrow/Free.hs
@@ -163,9 +163,9 @@ instance Arrow (A f) where
   second (A f) = A $ \k -> second (f k)
 
 instance Profunctor (A f) where
-  lmap f (A g) = A (\k -> g k . arr f)
+  lmap f (A g) = A (\k -> f ^>> g k)
   {-# INLINE lmap #-}
-  rmap f (A g) = A (\k -> arr f . g k)
+  rmap f (A g) = A (\k -> f ^<< g k)
   {-# INLINE rmap #-}
 
 type instance AlgebraType0 A f = ()

--- a/src/Control/Arrow/Free.hs
+++ b/src/Control/Arrow/Free.hs
@@ -35,7 +35,7 @@ module Control.Arrow.Free
   ) where
 
 import           Prelude hiding (id, (.))
-import           Control.Arrow (Arrow (..), ArrowChoice (..), (>>>))
+import           Control.Arrow (Arrow (..), ArrowChoice (..), (>>>), (^>>), (^<<))
 import           Control.Category (Category (..))
 import           Data.Profunctor (Profunctor (..))
 
@@ -103,8 +103,10 @@ instance Arrow (Arr f) where
   (&&&)     = Prod
 
 instance Profunctor (Arr f) where
-  lmap f a = arr f >>> a
+  lmap = (^>>)
+  {-# INLINE lmap #-}
   rmap = Arr
+  {-# INLINE rmap #-}
 
 type instance AlgebraType0 Arr f = ()
 type instance AlgebraType  Arr c = Arrow c
@@ -161,8 +163,10 @@ instance Arrow (A f) where
   second (A f) = A $ \k -> second (f k)
 
 instance Profunctor (A f) where
-  lmap f a = arr f >>> a
-  rmap f a = a >>> arr f
+  lmap = (^>>)
+  {-# INLINE lmap #-}
+  rmap = (^<<)
+  {-# INLINE rmap #-}
 
 type instance AlgebraType0 A f = ()
 type instance AlgebraType  A c = Arrow c

--- a/src/Control/Arrow/Free.hs
+++ b/src/Control/Arrow/Free.hs
@@ -163,9 +163,9 @@ instance Arrow (A f) where
   second (A f) = A $ \k -> second (f k)
 
 instance Profunctor (A f) where
-  lmap = (^>>)
+  lmap f (A g) = A (\k -> g k . arr f)
   {-# INLINE lmap #-}
-  rmap = (^<<)
+  rmap f (A g) = A (\k -> arr f . g k)
   {-# INLINE rmap #-}
 
 type instance AlgebraType0 A f = ()


### PR DESCRIPTION
# Features

Add `Control.Profunctor` instance declaration to free arrow classes.

# Breaking Changes

This PR will add dependencies on the package `profunctors`.

# Features Not Included

I tried to implement several abstraction on the type definitions of `Control.Arrow.Free.A`. This feature isn't included because I couldn't fix several type errors yet.